### PR TITLE
Add support for macOS/Linux/anything that can run a .NET 9 Console Application

### DIFF
--- a/UnConfuserEx/Protections/Constants/X86Resolver.cs
+++ b/UnConfuserEx/Protections/Constants/X86Resolver.cs
@@ -3,7 +3,6 @@ using dnlib.DotNet.Emit;
 using log4net;
 using System;
 using System.Collections.Generic;
-using System.Windows.Forms;
 using X86Emulator;
 
 namespace UnConfuserEx.Protections.Constants

--- a/UnConfuserEx/UnConfuserEx.csproj
+++ b/UnConfuserEx/UnConfuserEx.csproj
@@ -2,11 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0-windows10.0.17763.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <UseWindowsForms>True</UseWindowsForms>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "9.0.100",
+    "rollForward": "major",
+    "allowPrerelease": true
+  }
+}


### PR DESCRIPTION
Says it on the tin, tested and works on Linux (Fedora 43), has no reason not to work on any other system.

Additionally added a `global.json` to be more resilient to environments where a specific SDK may be targeted by default. Without it, this error can appear:
```
/home/emik/.dotnet/sdk/8.0.416/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(166,5): error NETSDK1045: The current .NET SDK does not support targeting .NET 9.0.  Either target .NET 8.0 or lower, or use a version of the .NET SDK that supports .NET 9.0. Download the .NET SDK from https://aka.ms/dotnet/download [/media/f/RiderProjects/Quarantine/UnconfuserEx.Fork/MSILEmulator/MSILEmulator.csproj]
/home/emik/.dotnet/sdk/8.0.416/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(166,5): error NETSDK1045: The current .NET SDK does not support targeting .NET 9.0.  Either target .NET 8.0 or lower, or use a version of the .NET SDK that supports .NET 9.0. Download the .NET SDK from https://aka.ms/dotnet/download [/media/f/RiderProjects/Quarantine/UnconfuserEx.Fork/X86Emulator/X86Emulator.csproj]
/home/emik/.dotnet/sdk/8.0.416/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(166,5): error NETSDK1045: The current .NET SDK does not support targeting .NET 9.0.  Either target .NET 8.0 or lower, or use a version of the .NET SDK that supports .NET 9.0. Download the .NET SDK from https://aka.ms/dotnet/download [/media/f/RiderProjects/Quarantine/UnconfuserEx.Fork/UnConfuserEx/UnConfuserEx.csproj]
```